### PR TITLE
ノートの一覧ページからノートの削除ができるようにした

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -33,7 +33,7 @@ class NotesController < ApplicationController
 
   def destroy 
     note = Note.find(params[:id])
-    note.delete
+    note.destroy
     redirect_to notes_path
   end
 

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -31,6 +31,12 @@ class NotesController < ApplicationController
     end
   end
 
+  def destroy 
+    note = Note.find(params[:id])
+    note.delete
+    redirect_to notes_path
+  end
+
   def user_params
     params.require(:note).permit('title', 'content')
   end

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -8,6 +8,7 @@
     <th>作成者ID</th>
     <th>更新日時</th>
     <th>編集</th>
+    <th>削除</th>
   </thead>
   <tbody>
     <% @notes.each do |item| %>
@@ -15,7 +16,8 @@
         <td><%= item.title %></td>
         <td><%= item.author.account %></td>
         <td><%= item.updated_at %></td>
-        <td><%= link_to '編集', edit_note_path(item.id) %></td>
+        <td><%= link_to '編集', edit_note_path(item.id), :class => "btn btn-success btn-xs" %></td>
+        <td><%= link_to '削除', note_path(item.id), :method => :delete, data: { confirm: "#{item.title} を削除します" }, :class => "btn btn-danger btn-xs" %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
ノートの一覧ページに記事の削除ボタンをつけました。
既にあった編集ボタンと、新規で作成した削除ボタンをBootstrapに対応させました。
